### PR TITLE
Use meta to operate on set of client repositories.

### DIFF
--- a/META.md
+++ b/META.md
@@ -1,0 +1,97 @@
+- [Managing OpenSearch Clients](#managing-opensearch-clients)
+  - [Install GH](#install-gh)
+  - [Install Meta](#install-meta)
+  - [Check Out Clients](#check-out-clients)
+  - [Get Repo Info](#get-repo-info)
+  - [Add a New Client](#add-a-new-client)
+  - [Create or Update Labels in All Client Repos](#create-or-update-labels-in-all-client-repos)
+  - [Create an Issue in All Client Repos](#create-an-issue-in-all-client-repos)
+  - [Open a Pull Request in Each Repo](#open-a-pull-request-in-each-repo)
+
+## Managing OpenSearch Clients
+
+We use [meta](https://github.com/mateodelnorte/meta) to manage OpenSearch clients as a set.
+
+### Install GH
+
+Install and configure GitHub CLI from [cli.github.com/manual/installation](https://cli.github.com/manual/installation). Authenticate with `gh auth login` and ensure that it works, e.g. `gh issue list`.
+
+### Install Meta
+
+```sh
+npm install -g meta
+```
+
+### Check Out Clients
+
+```sh
+cd clients
+meta git update
+```
+
+Use `meta git pull` to subsequently pull the latest revisions.
+
+### Get Repo Info
+
+```sh
+clients> meta gh issue list
+```
+
+### Add a New Client
+
+```sh
+cd clients
+meta project import opensearch-new-client git@github.com:opensearch-project/opensearch-new-client.git
+```
+
+### Create or Update Labels in All Client Repos
+
+Install [ghi](https://github.com/stephencelis/ghi), e.g. `brew install ghi`.
+
+```
+meta exec "ghi label 'backwards-compatibility' -c '#773AA8'
+```
+
+This makes it easy to create version labels.
+
+```
+meta exec "ghi label 'untriaged' -c '#fbca04'"
+meta exec "ghi label 'v1.0.0' -c '#d4c5f9'"
+meta exec "ghi label 'v1.1.0' -c '#c5def5'"
+meta exec "ghi label 'v2.0.0' -c '#b94c47'"
+```
+
+### Create an Issue in All Client Repos
+
+Create a file for the issue body, e.g. `issue.md`.
+
+```
+meta exec "gh issue create --label backwards-compatibility --title 'Ensure backwards compatibility with ODFE' --body-file ../issue.md"
+```
+
+### Open a Pull Request in Each Repo
+
+In [opensearch-build#497](https://github.com/opensearch-project/opensearch-build/issues/497) we needed to remove `integtest.sh` from each repo.
+
+We'll be pushing to forks. Make sure to replace `username` with your GitHub username below and to fork all the repos first.
+
+```
+meta exec "gh repo fork"
+```
+
+Ensure that a remote is setup for each client pointing to our forks.
+
+```
+meta exec "git remote get-url origin | sed s/opensearch-project/username/g | xargs git remote add username"
+```
+
+Remove a file, e.g. `integtest.sh`, commit and push.
+
+```
+meta exec "git rm integtest.sh"
+meta exec "git add --all"
+meta exec "git checkout -b remove-integtest-sh"
+meta exec "git commit -s -m 'Removed integtest.sh.'"
+meta exec "git push username remove-integtest-sh"
+meta exec "gh pr create --title 'Removing default integtest.sh.' --body='Coming from https://github.com/opensearch-project/opensearch-build/issues/497, removing default integtest.sh.'"
+```

--- a/clients/.gitignore
+++ b/clients/.gitignore
@@ -1,0 +1,8 @@
+/opensearch-dsl-py/
+/opensearch-go/
+/opensearch-java/
+/opensearch-js/
+/opensearch-net/
+/opensearch-php/
+/opensearch-py/
+/opensearch-ruby/

--- a/clients/.meta
+++ b/clients/.meta
@@ -1,0 +1,12 @@
+{
+    "projects": {
+        "opensearch-dsl-py" : "git@github.com:opensearch-project/opensearch-dsl-py.git",
+        "opensearch-go"     : "git@github.com:opensearch-project/opensearch-go.git",
+        "opensearch-java"   : "git@github.com:opensearch-project/opensearch-java.git",
+        "opensearch-js"     : "git@github.com:opensearch-project/opensearch-js.git",
+        "opensearch-net"    : "git@github.com:opensearch-project/opensearch-net.git",
+        "opensearch-php"    : "git@github.com:opensearch-project/opensearch-php.git",
+        "opensearch-py"     : "git@github.com:opensearch-project/opensearch-py.git",
+        "opensearch-ruby"   : "git@github.com:opensearch-project/opensearch-ruby.git"
+    }
+}


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Use meta to operate on set of client repositories. Added only active client repositories.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
