### PR TITLE
Fix GH cli installation link

### DIFF
--- a/META.md
+++ b/META.md
@@ -14,7 +14,7 @@ We use [meta](https://github.com/mateodelnorte/meta) to manage OpenSearch client
 
 ### Install GH
 
-Install and configure GitHub CLI from [cli.github.com/manual/installation](https://cli.github.com/manual/installation). Authenticate with `gh auth login` and ensure that it works, e.g. `gh issue list`.
+Install and configure GitHub CLI from [github.com/cli/cli](https://github.com/cli/cli#installation). Authenticate with `gh auth login` and ensure that it works, e.g. `gh issue list`.
 
 ### Install Meta
 


### PR DESCRIPTION
### Description
Fix GH cli installation link

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
