### PR TITLE
Adding Xtansia to opensearch-clients maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @VachaShah @dblock @harshavamsi
+*   @VachaShah @dblock @harshavamsi @Xtansia

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,11 +4,12 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer              | GitHub ID                                     | Affiliation |
-| ----------------------- | --------------------------------------------- | ----------- |
-| Daniel Doubrovkine      | [dblock](https://github.com/dblock)           | Amazon      |
-| Harsha Vamsi Kalluri    | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
-| Vacha Shah              | [VachaShah](https://github.com/VachaShah)     | Amazon      |
+| Maintainer           | GitHub ID                                     | Affiliation |
+| -------------------- | --------------------------------------------- | ----------- |
+| Daniel Doubrovkine   | [dblock](https://github.com/dblock)           | Amazon      |
+| Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
+| Thomas Farr          | [Xtansia](https://github.com/Xtansia)         | Amazon      |
+| Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description

Following a successful nomination of @Xtansia to maintainers of this project after recent [fixes](https://github.com/opensearch-project/opensearch-clients/pull/75) and [updates](https://github.com/opensearch-project/opensearch-clients/pull/74). 

This is a super low volume repo so now he’s a major contributor to it ;)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
